### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ project(VolumeClip)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "http://www.slicer.org/slicerWiki/index.php/Documentation/4.3/Extensions/VolumeClip")
+set(EXTENSION_HOMEPAGE "https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/VolumeClip")
 set(EXTENSION_CATEGORY "Segmentation")
 set(EXTENSION_CONTRIBUTORS "Andras Lasso, Matt Lougheed (PerkLab, Queen's University)")
 set(EXTENSION_DESCRIPTION "Clip volumes with surface models and ROI boxes")
-set(EXTENSION_ICONURL "http://www.slicer.org/slicerWiki/images/c/c2/VolumeClipLogo.png")
-set(EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/images/4/4c/VolumeClipScreenshot1.png http://www.slicer.org/slicerWiki/images/5/57/VolumeClipScreenshot2.png http://www.slicer.org/slicerWiki/images/1/1a/VolumeClipScreenshot3.png")
+set(EXTENSION_ICONURL "https://www.slicer.org/slicerWiki/images/c/c2/VolumeClipLogo.png")
+set(EXTENSION_SCREENSHOTURLS "https://www.slicer.org/slicerWiki/images/4/4c/VolumeClipScreenshot1.png https://www.slicer.org/slicerWiki/images/5/57/VolumeClipScreenshot2.png https://www.slicer.org/slicerWiki/images/1/1a/VolumeClipScreenshot3.png")
 
 #-----------------------------------------------------------------------------
 # Extension dependencies


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.